### PR TITLE
Update protobuf types to 1.1 and make the service depend on it.

### DIFF
--- a/Source/Build Specs/Measurement Plug-In SDK Service.vipb
+++ b/Source/Build Specs/Measurement Plug-In SDK Service.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2024-06-18 09:01:09" Creator="lvadmin" Comments="" ID="fa9b35f0f61e0151317dd8dad63f4481">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2024-06-18 11:46:10" Creator="lvadmin" Comments="" ID="53de7ca060f40161264fbb42cd6e8f73">
   <Library_General_Settings>
     <Package_File_Name>ni_measurement_plugin_sdk_service</Package_File_Name>
     <Library_Version>3.0.0.1</Library_Version>
@@ -19,7 +19,7 @@
     <Package_Dependencies>
       <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.1.1</Additional_External_Dependencies>
       <Additional_External_Dependencies>ni_lib_labview_grpc_servicer &gt;=1.0.1.1</Additional_External_Dependencies>
-      <Additional_External_Dependencies>ni_protobuf_types &gt;=1.0.0.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_protobuf_types &gt;=1.1.0.1</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI>Build Custom Actions\Pre-Build Custom Action.vi</Pre-Build_VI>

--- a/Source/Build Specs/ni_protobuf_types.vipb
+++ b/Source/Build Specs/ni_protobuf_types.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-11-27 13:47:44" Creator="lvadmin" Comments="" ID="2a6d08d1d469108e8e2b0af2a497cfbc">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2024-06-18 11:45:22" Creator="lvadmin" Comments="" ID="8e3132d591cffc522dea61ef75e1e104">
   <Library_General_Settings>
     <Package_File_Name>ni_protobuf_types</Package_File_Name>
-    <Library_Version>1.0.0.1</Library_Version>
+    <Library_Version>1.1.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\gRPC\Generated APIs\ni\protobuf\types</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>
@@ -32,7 +32,7 @@
       <Copyright/>
       <Packager>NI</Packager>
       <URL/>
-      <Release_Notes/>
+      <Release_Notes>Add Double Analog Waveform data type to the package.</Release_Notes>
     </Description>
     <Destinations>
       <Toolkit_VIs>


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_

### What does this Pull Request accomplish?

Updates the NI gRPC Types (ni_protobuf_types) package version. Make the service package depend on the new version.

### Why should this Pull Request be merged?

A new version is required to include the waveform data type.

### What testing has been done?

Installed package locally.