### PR TITLE
Make the Resolve Service VI public

### DIFF
--- a/Source/Runtime/Clients/Discovery V1/NI Discovery V1 Client.lvlib
+++ b/Source/Runtime/Clients/Discovery V1/NI Discovery V1 Client.lvlib
@@ -25,9 +25,7 @@
 		<Item Name="Recreate Client.vi" Type="VI" URL="../Recreate Client.vi">
 			<Property Name="NI.LibItem.Scope" Type="Int">2</Property>
 		</Item>
-		<Item Name="Resolve Service.vi" Type="VI" URL="../Resolve Service.vi">
-			<Property Name="NI.LibItem.Scope" Type="Int">4</Property>
-		</Item>
+		<Item Name="Resolve Service.vi" Type="VI" URL="../Resolve Service.vi"/>
 	</Item>
 	<Item Name="Discovery Service Helpers" Type="Folder">
 		<Item Name="Ensure Discovery Service Started.vi" Type="VI" URL="../Ensure Discovery Service Started.vi">


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_
- [ ] <!--G_DIFF_CHECK--> Automatically post PR comments with images for G code changes? _(Recommended for small changes)_

### What does this Pull Request accomplish?
As part of Measurement Plug-In Client generator, we need to create configuration and result controls for the measurement client. This requires the service’s metadata. To obtain the metadata, the location and port details of the service are required. Thus, made the `Resolve Service.vi` of `NI Discovery V1 Client.lvlib` public. 
P.S This change of scope aligns with the discussions regarding `Enumerate Services.vi` [#571](https://github.com/ni/measurement-plugin-labview/pull/571)

### Why should this Pull Request be merged?

To update the scope of `Resolve Service.vi`, as it is a dependency for Measurement Plug-In Client generator.

### What testing has been done?

None