### PR TITLE
renovate: Fix Git submodule scheduling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     },
     "packageRules": [
       {
-        "matchPackagePrefixes": ["third_party/"],
+        "matchDepNames": ["third_party/ni-apis", "third_party/protobuf"],
         "extends": ["schedule:monthly"]
       }
     ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "packageRules": [
       {
         "matchDepNames": ["third_party/ni-apis", "third_party/protobuf"],
-        "extends": ["schedule:monthly"]
+        "extends": ["schedule:monthly", ":dependencyDashboardApproval"]
       }
     ]
   }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_
- [ ] <!--G_DIFF_CHECK--> Automatically post PR comments with images for G code changes? _(Recommended for small changes)_

### What does this Pull Request accomplish?

The previous scheduling config was not working because `third_party/ni-apis` is a `depName`, not a `packageName`.

At one point, `matchPackageNames` used to match against dep names, but this behavior has been removed. https://github.com/renovatebot/renovate/discussions/25233

Enable "Dependency Dashboard Approval", which prevents Renovate from creating a PR until someone approves via the [Dependency Dashboard](https://github.com/ni/measurement-plugin-labview/issues/408).

### Why should this Pull Request be merged?

Disable Renovate PRs for Git submodules unless approved via the [Dependency Dashboard](https://github.com/ni/measurement-plugin-labview/issues/408).

### What testing has been done?

When I made the same change in another repo, I checked the Renovate log and verified that it listed the right schedule info.

"Dependency Dashboard Approval" is untested.