### PR TITLE
[Minor] Docs: Update README for Measurement Plug-In Client Generator to recommend gRPC library version 1.0.1.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,10 @@ Note:
 
 ## Generating a LabVIEW measurement client
 
+Note:
+
+The gRPC library version 1.0.1.1 is recommended for the LabVIEW Measurement Client Generator. If you still want to work with a gRPC library version higher than 1.0.1.1, you should manually set the value of `EfficientMessageCopy` to FALSE in the `feature_config.ini` file located at `C:\Program Files\National Instruments\LabVIEW 20XX\vi.lib\gRPC\LabVIEW gRPC Library\Libraries\Win64\`.
+
 1. Create and save a new LabVIEW project.
 
 2. From the project window, go to `Tools` → `Plug-In SDKs` → `Measurements` → `Create Measurement Plug-in Client...`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,11 @@ Note:
 
 The gRPC library version 1.0.1.1 is recommended for the LabVIEW Measurement Client Generator. If you still want to work with a gRPC library version higher than 1.0.1.1, you should manually set the value of `EfficientMessageCopy` to FALSE in the `feature_config.ini` file located at `C:\Program Files\National Instruments\LabVIEW 20XX\vi.lib\gRPC\LabVIEW gRPC Library\Libraries\Win64\`.
 
+```.ini
+[data]
+EfficientMessageCopy = FALSE
+```
+
 1. Create and save a new LabVIEW project.
 
 2. From the project window, go to `Tools` → `Plug-In SDKs` → `Measurements` → `Create Measurement Plug-in Client...`.


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_
- [ ] <!--G_DIFF_CHECK--> Automatically post PR comments with images for G code changes? _(Recommended for small changes)_

### What does this Pull Request accomplish?

- Updated the `README.md` file to explicitly recommend using gRPC-LabVIEW version 1.0.1.1 for the Client Generator. If a higher version of gRPC-LabVIEW is used, the documentation now advises editing the feature_config.ini file to ensure compatibility.

### Why should this Pull Request be merged?

- [Context](https://github.com/ni/measurement-plugin-labview/pull/619#issuecomment-2411640790)

### What testing has been done?

None