### PR TITLE
[Releases/3.1] Cherry pick: Add David Curtiss as code owner (#623)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default code owner for the repository
-* @dixonjoel @aepete @jasonmreding
+* @dixonjoel @aepete @jasonmreding @DavidCurtiss
 
 # Add nstokes-nati for documentation
-*.md @dixonjoel @aepete @jasonmreding @nstokes-nati
-/docs/ @dixonjoel @aepete @jasonmreding @nstokes-nati
+*.md @dixonjoel @aepete @jasonmreding @DavidCurtiss @nstokes-nati
+/docs/ @dixonjoel @aepete @jasonmreding @DavidCurtiss @nstokes-nati


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_

### What does this Pull Request accomplish?

Cherry pick the codeowners change to releases/3.1

### Why should this Pull Request be merged?

David will be able to review my PRs in releases/3.1 with other owners out.
